### PR TITLE
Add a membership template and information

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.yml
+++ b/.github/ISSUE_TEMPLATE/membership.yml
@@ -1,0 +1,64 @@
+name: Consortium Membership
+description: Application to become a Safety Critical Rust Consortium Member
+title: Membership Application for [INSERT COMPANY, INSTITUION, YOUR NAME, OR OTHER ENTITY]
+labels: [membership, 'status: needs review']
+assignees: 
+  - joelmarcey
+body:
+  - type: markdown
+    attribute:
+      value: |
+        The Safety Critical Rust Consortium was announced in June 2024 with a goal to support the responsible use of Rust in Safety Critical software. The mission of the consortium is to improve the suitability of Rust in safety critical applications.
+        
+        Membership into the consortium is free and available to those with a noted and vested interested in the safety critical space. There are two types of membership:
+        - Producer: An active participant in the consortium, helping drive its mission
+        - Observers: A passive participant who wants to keep up with the consortium's happenings. Observers generally virtually attend meetings and listen in.
+        
+        This distinction is mainly for housekeeping purposes. You can choose which type of membership you plan to be initially and change it as needed.
+
+        If you do become a member of the consortium, you will be added to the consortium mailing list, which is currently the only non-public asset of the consortium at this point.
+  - type: input
+    id: Name
+    attributes:
+      label: What is your name?
+    validations:
+      required: true
+  - type: dropdown
+    id: representation
+    attributes:
+      label: Do you represent a company, institution, consortium, yourself or other entity?
+      description: In what capacity will you be represented as a member of the consortium?
+        - label: Company
+          required: false
+        - label: Institution (Academic, etc.)
+          required: false
+        - label: Consortium
+          required: false
+        - label: Myself
+          required: false
+        - label: Other Entity
+          required: false
+    validations:
+      required: true
+  - type: textarea
+    id: entity-name
+    attributes:
+      label: If you represent a company, institution, consortium, or other entity, please enter it here:
+      description: If you are representing other than yourself, please enter it. Otherwise, keep the default as 'individual'.
+      placeholder: Individual
+    validations:
+      required: true
+  - type: textarea
+    id: why-interested
+    attributes:
+      label: Why are you interested in joining the Safety Critical Rust Consortium?
+      description: If applicable, describe work that you are doing or planning to do in the safety critical space.
+    validations:
+      required: true
+  - type: dropdown
+    id: membership-type
+    attributes:
+      label: Do you plan to be a producer or observer in the consortium?
+      description: See above for the distinction between these two membership types. They are used mainly for housekeeping purposes and can be changed.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/membership.yml
+++ b/.github/ISSUE_TEMPLATE/membership.yml
@@ -1,6 +1,6 @@
 name: Consortium Membership
 description: Application to become a Safety Critical Rust Consortium Member
-title: Membership Application for [INSERT COMPANY, INSTITUION, YOUR NAME, OR OTHER ENTITY]
+title: Membership Application for [INSERT COMPANY, INSTITUTION, YOUR NAME, OR OTHER ENTITY]
 labels: [membership, 'status: needs review']
 assignees: 
   - joelmarcey
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attribute:
       value: |
-        The Safety Critical Rust Consortium was announced in June 2024 with a goal to support the responsible use of Rust in Safety Critical software. The mission of the consortium is to improve the suitability of Rust in safety critical applications.
+        The [Safety Critical Rust Consortium](https://github.com/rustfoundation/safety-critical-rust-consortium) was [announced](https://foundation.rust-lang.org/news/announcing-the-safety-critical-rust-consortium/) in June 2024 with a goal to support the responsible use of Rust in Safety Critical software. The mission of the consortium is to improve the suitability of Rust in safety critical applications.
         
         Membership into the consortium is free and available to those with a noted and vested interested in the safety critical space. There are two types of membership:
         - Producer: An active participant in the consortium, helping drive its mission

--- a/.github/ISSUE_TEMPLATE/membership.yml
+++ b/.github/ISSUE_TEMPLATE/membership.yml
@@ -28,16 +28,13 @@ body:
     attributes:
       label: Do you represent a company, institution, consortium, yourself or other entity?
       description: In what capacity will you be represented as a member of the consortium?
-        - label: Company
-          required: false
-        - label: Institution (Academic, etc.)
-          required: false
-        - label: Consortium
-          required: false
-        - label: Myself
-          required: false
-        - label: Other Entity
-          required: false
+      options:
+        - Company
+        - Institution (Academic, etc.)
+        - Consortium
+        - Myself
+        - Other Entity
+      default: 0
     validations:
       required: true
   - type: textarea
@@ -60,5 +57,9 @@ body:
     attributes:
       label: Do you plan to be a producer or observer in the consortium?
       description: See above for the distinction between these two membership types. They are used mainly for housekeeping purposes and can be changed.
+      options:
+        - Producer
+        - Observer
+      default: 1
     validations:
       required: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ In June 2024, the Rust Foundation, AdaCore, Arm, Ferrous Systems, HighTec EDV-Sy
 
 See the full announcement [here](https://foundation.rust-lang.org/news/announcing-the-safety-critical-rust-consortium/).
 
+## Membership
+
+Membership to the Safety Critical Rust Consortium is free. Please file this GitHub issue to submit your membership application.
+
 ## [Code of Conduct][code-of-conduct]
 
 The [Rust Foundation][rust-foundation] has adopted a Code of Conduct that we
@@ -11,7 +15,7 @@ expect project participants to adhere to. Please read [the full
 text][code-of-conduct] so that you can understand what actions will and will not
 be tolerated.
 
-## Contributing
+## Contributing to This Repository
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ See the full announcement [here](https://foundation.rust-lang.org/news/announcin
 
 ## Consortium Membership
 
-Membership to the Safety Critical Rust Consortium is free. Please [file this GitHub issue](https://github.com/rustfoundation/safety-critical-rust-consortium/issues/new?assignees=joelmarcey&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml) to submit your membership application.
+Membership to the Safety Critical Rust Consortium is free. Please [file this GitHub issue](https://github.com/rustfoundation/safety-critical-rust-consortium/issues/new?assignees=joelmarcey&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml) to submit your membership application. 
+
+If for some reason you are unable or willing to file the application for membership via a GitHub issue, please send an email to `safety-critical-rust-consortium-contact [at] rustfoundation [dot] org`.
 
 ## [Code of Conduct][code-of-conduct]
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ In June 2024, the Rust Foundation, AdaCore, Arm, Ferrous Systems, HighTec EDV-Sy
 
 See the full announcement [here](https://foundation.rust-lang.org/news/announcing-the-safety-critical-rust-consortium/).
 
-## Membership
+## Consortium Membership
 
-Membership to the Safety Critical Rust Consortium is free. Please file this GitHub issue to submit your membership application.
+Membership to the Safety Critical Rust Consortium is free. Please [file this GitHub issue](https://github.com/rustfoundation/safety-critical-rust-consortium/issues/new?assignees=joelmarcey&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml) to submit your membership application.
 
 ## [Code of Conduct][code-of-conduct]
 


### PR DESCRIPTION
This uses GitHub issue templates to create a form that will be filled out and filed as a GitHub issue in the repository for membership. 

This will be tested and tweaked once it gets merged since it has to integrate with the Issues page directly.