### PR TITLE
[Coding Guidelines] Add agenda for next meeting: 05-November-2024

### DIFF
--- a/subcommittee/coding-guidelines/meetings/05-November-2024/agenda.md
+++ b/subcommittee/coding-guidelines/meetings/05-November-2024/agenda.md
@@ -1,0 +1,37 @@
+# Coding Guidelines Subcommittee Meeting on 2024-11-05
+
+## Agenda
+
+1. Acceptance of Previous Meeting Minutes   
+2. Contributor Expectations - Online discussion
+3. Safe Use of Unsafe Guidelines - Online discussion
+4. Round table
+
+Supplemental material to the agenda can be found on the [GitHub repo](https://github.com/rustfoundation/safety-critical-rust-consortium/tree/main/subcommittee/coding-guidelines).
+
+## Check-in area
+
+**Please add your name, and an emoji that describes your day.**
+
+
+
+**Notetaker:** 
+
+
+
+## Housekeeping section, please add 
+
+* Document space: https://github.com/rustfoundation/safety-critical-rust-consortium/tree/main/subcommittee/coding-guidelines  
+* Zulip: [safety-critical-consortium: Coding Guidelines](https://rust-lang.zulipchat.com/#narrow/channel/445688-safety-critical-consortium/topic/Coding.20Guidelines)
+
+## Tasks
+
+
+
+## Meeting Minutes:
+
+
+## Material
+
+Any material to read before the meeting should be included here.
+

--- a/subcommittee/coding-guidelines/meetings/05-November-2024/agenda.md
+++ b/subcommittee/coding-guidelines/meetings/05-November-2024/agenda.md
@@ -3,9 +3,10 @@
 ## Agenda
 
 1. Acceptance of Previous Meeting Minutes   
-2. Contributor Expectations - Online discussion
-3. Safe Use of Unsafe Guidelines - Online discussion
-4. Round table
+2. Contributor Expectations - Online discussion (Pete LeVasseur)
+3. Safe Use of Unsafe Guidelines - Online discussion (Pete LeVasseur)
+4. MISRA + Rust (Alex Celeste)
+5. Round table
 
 Supplemental material to the agenda can be found on the [GitHub repo](https://github.com/rustfoundation/safety-critical-rust-consortium/tree/main/subcommittee/coding-guidelines).
 


### PR DESCRIPTION
Hey folks :wave: 

Feel free to leave comments for other agenda items you'd find interesting. You can also leave items here that you'd like to have brought, but not in this session.  I can then add them to the [Coding Guidelines Topics of Interest board](https://github.com/orgs/rustfoundation/projects/1/views/1).

It sounds like after we've worked through officially adding all the members, then we can add write privileges to allow others to just add what they're interested in bringing to the meeting as well.