### PR TITLE
Add form for joining subcommittees

### DIFF
--- a/.github/ISSUE_TEMPLATE/subcommittees.yml
+++ b/.github/ISSUE_TEMPLATE/subcommittees.yml
@@ -1,0 +1,55 @@
+name: Consortium Subcommittee Membership
+description: Application to join a Safety Critical Rust Consortium Sub Committee
+title: Subcommittee Join Request for [NAME]
+labels: ["subcommittee application"]
+assignees: 
+  - joelmarcey, PLeVasseur, alexandruradovici
+body:
+  - type: markdown
+    attributes:
+      value: |
+        NOTE: IF YOU HAVE NOT YET SUBMITTED AN APPLICATION TO JOIN THE SAFETY CRITICAL RUST CONSORTIUM ITSELF, PLEASE [DO SO FIRST](https://github.com/rustfoundation/safety-critical-rust-consortium?tab=readme-ov-file#consortium-membership) BEFORE FILLING OUT THIS FORM.
+        
+        The [Safety Critical Rust Consortium](https://github.com/rustfoundation/safety-critical-rust-consortium) currently has two subcommittees:
+
+        1. [Coding Guidelines](https://github.com/JoelMarcey/safety-critical-rust-consortium/tree/main/subcommittee/coding-guidelines)
+        2. [Tooling](https://github.com/JoelMarcey/safety-critical-rust-consortium/tree/main/subcommittee/tooling)
+
+        Use this form to join one of those committees. If you want to join more than one subcommittee, fill out this form multiple times.
+ - type: dropdown
+    id: current-consortium-member
+    attributes:
+      label: Are you already a member of the Safety Critical Rust Consortium?
+      description: If you are not already a member of the Safety Critical Rust Consortium, please join first as described above before filling out this form.
+      options:
+        - Yes
+        - No
+      default: 1
+    validations:
+      required: true  
+  - type: input
+    id: Name
+    attributes:
+      label: What is your name?
+    validations:
+      required: true
+  - type: dropdown
+    id: subcommittee
+    attributes:
+      label: What subcommittee would you like to join?
+      description: Choose which subcommittee you would like to join.
+      options:
+        - Coding Guidelines
+        - Tooling
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: subcommittee-membership-type
+    attributes:
+      label: [ONLY FILL THIS OUT IF YOU ARE A PRODUCER IN THE CONSORTIUM. IF YOU ARE AN OBSERVER, YOU WILL BE AN OBSERVER IN THE SUBCOMMITTEE BY DEFAULT] Do you plan to be a producer or observer in this subcommittee?
+      description: If you are a producer in the consortium, choose if you plan to be active in the subcommittee (producer) or passive (observer)
+      options:
+        - Producer
+        - Observer
+      default: 1

--- a/.github/workflows/add-membership-application-to-project.yml
+++ b/.github/workflows/add-membership-application-to-project.yml
@@ -1,4 +1,4 @@
-name: Add membership application to membership GitHub roject
+name: Add membership application to membership GitHub Project
 
 on:
   issues:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ If for some reason you are unable or willing to file the application for members
 
 Whether you become a member or not, you can join the consortium's [public Zulip channel](https://rust-lang.zulipchat.com/#narrow/channel/445688-safety-critical-consortium) to keep up with various happenings.
 
+### Subcommittee Membership
+
+The Safety Critical Rust Consortium has subcommittees that focuses on specific areas of work. 
+
+Right now there are two subcommittees:
+
+1. Coding Guidelines
+2. Tooling
+
+After you join the consortium, you can apply to be a member of one or more of the subcommittees as well.
+
+*Note: If you are an observer of the consortium, you will be an observer in the subcommittee. If you are a producer of the consortium, you can choose*
+
 ## [Code of Conduct][code-of-conduct]
 
 The [Rust Foundation][rust-foundation] has adopted a Code of Conduct that we


### PR DESCRIPTION
This form can be used to join any of the current subcommittes. The resulting issue will be assigned to all leads/chairs and triage can happen from there.