### PR TITLE
[tooling] meeting 06.12 agenda

### DIFF
--- a/subcommittee/tooling/meetings/6-December-2024/agenda.md
+++ b/subcommittee/tooling/meetings/6-December-2024/agenda.md
@@ -1,0 +1,10 @@
+# Tooling Subcommittee - 6-December-2024
+
+## Meeting Time
+
+6-December-2024 @ 3-4pm UTC
+
+## Agenda Items
+
+1. Mapping the different industry standards to Rust Safety Levels
+2. Mapping the required tools to the Rust Safety Levels


### PR DESCRIPTION
This pull request adds the agenda for the 06.12 meeting.

[Rendered](https://github.com/rustfoundation/safety-critical-rust-consortium/blob/1ef5b40443d7f7576d1cba5639c01e0a8a29e884/subcommittee/tooling/meetings/6-December-2024/agenda.md)
