### PR TITLE
[Coding Guidelines] Add agenda for 2024-12-18 meeting

### DIFF
--- a/subcommittee/coding-guidelines/meetings/2024-December-18/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2024-December-18/minutes.md
@@ -1,0 +1,35 @@
+# Coding Guidelines Subcommittee Meeting on 2024-12-18 @ 3pm UTC
+
+## Agenda
+
+1. Acceptance of [Previous Meeting Minutes](../2024-December-04/minutes.md)
+2. `unsafe` Practicum Chapter Task Force - progress report (Jordan McQueen)
+3. `unsafe` Docs Review Task Force - progress report (Pete LeVasseur)
+4. Round table
+
+Supplemental material to the agenda can be found on the [GitHub repo](https://github.com/rustfoundation/safety-critical-rust-consortium/tree/main/subcommittee/coding-guidelines).
+
+## Check-in area
+
+**Please add your name, and an emoji that describes your day.**
+
+* 
+
+**Notetaker:**
+
+* 
+
+## Housekeeping section, please add
+
+* Document space: https://github.com/rustfoundation/safety-critical-rust-consortium/tree/main/subcommittee/coding-guidelines
+* Zulip: [safety-critical-consortium: Coding Guidelines](https://rust-lang.zulipchat.com/#narrow/channel/445688-safety-critical-consortium/topic/Coding.20Guidelines)
+
+## Tasks
+
+* 
+
+## Meeting Minutes:
+
+* ## Material
+
+Any material to read before the meeting should be included here.


### PR DESCRIPTION
Hi folks :wave: 

Feel free to add any additional items you'd like to discuss.

@AlexCeleste -- if you'd like to bring a discussion of the work you're doing for Rust + MISRA we can do so this time :)

edit: (Adding @alexandruradovici on backup approval as I see @JoelMarcey is on vacation via Zulip 🌴)