### PR TITLE
Add pointer arithmetic example

### DIFF
--- a/subcommittee/coding-guidelines/initiatives/safe-use-of-unsafe-guidelines/learn_unsafe_rust/src/core_unsafety/dangling_and_unaligned_pointers.md
+++ b/subcommittee/coding-guidelines/initiatives/safe-use-of-unsafe-guidelines/learn_unsafe_rust/src/core_unsafety/dangling_and_unaligned_pointers.md
@@ -1,0 +1,29 @@
+# Dangling and unaligned pointers
+
+
+## Pointer Arithmetic
+
+In connection with [Allocation](https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#allocation), operations involving pointer arithmetic, which require resorting to the unsafe keyword, are safe as long as the resulting pointers are within the bounds of the allocated memory.
+
+This might be needed when working with a foreign function interface ([FFI](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#using-extern-functions-to-call-external-code)), for example processing a C-style array - given by a pointer and a length.
+
+```rust
+fn safe_pointer_arithmetic() {
+    let mut values = vec![1, 2, 3, 4, 5];
+
+    // SAFETY: get a raw pointer to the start of the vector, which is valid
+    // using `as_mut_ptr` as long as the vector exists and isn't reallocated.
+    let ptr = values.as_mut_ptr();
+    let len = values.len();
+
+    for i in 0..len {
+        unsafe {
+            // SAFETY: pointer arithmetic within the bounds of the vector.
+            let elem_ptr = ptr.add(i);
+
+            // SAFETY: dereference is safe because 0 <= i < len.
+            *elem_ptr *= 2;
+        }
+    }
+}
+```

--- a/subcommittee/coding-guidelines/initiatives/safe-use-of-unsafe-guidelines/unsafe-example-usage.md
+++ b/subcommittee/coding-guidelines/initiatives/safe-use-of-unsafe-guidelines/unsafe-example-usage.md
@@ -87,3 +87,30 @@ pub struct Vec<T> {
     len: usize,
 }
 ```
+
+## Example 3 -- Pointer Arithmetic 
+
+In connection with [Allocation](https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#allocation), operations involving pointer arithmetic, which require resorting to the unsafe keyword, are safe as long as the resulting pointers are within the bounds of the allocated memory.
+
+This might be needed when working with a foreign function interface ([FFI](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#using-extern-functions-to-call-external-code)), for example processing a C-style array - given by a pointer and a length.
+
+```rust
+fn safe_pointer_arithmetic() {
+    let mut values = vec![1, 2, 3, 4, 5];
+
+    // SAFETY: get a raw pointer to the start of the vector, which is valid
+    // using `as_mut_ptr` as long as the vector exists and isn't reallocated.
+    let ptr = values.as_mut_ptr();
+    let len = values.len();
+
+    for i in 0..len {
+        unsafe {
+            // SAFETY: pointer arithmetic within the bounds of the vector.
+            let elem_ptr = ptr.add(i);
+
+            // SAFETY: dereference is safe because 0 <= i < len.
+            *elem_ptr *= 2;
+        }
+    }
+}
+```

--- a/subcommittee/coding-guidelines/initiatives/safe-use-of-unsafe-guidelines/unsafe-example-usage.md
+++ b/subcommittee/coding-guidelines/initiatives/safe-use-of-unsafe-guidelines/unsafe-example-usage.md
@@ -87,30 +87,3 @@ pub struct Vec<T> {
     len: usize,
 }
 ```
-
-## Example 3 -- Pointer Arithmetic 
-
-In connection with [Allocation](https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#allocation), operations involving pointer arithmetic, which require resorting to the unsafe keyword, are safe as long as the resulting pointers are within the bounds of the allocated memory.
-
-This might be needed when working with a foreign function interface ([FFI](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#using-extern-functions-to-call-external-code)), for example processing a C-style array - given by a pointer and a length.
-
-```rust
-fn safe_pointer_arithmetic() {
-    let mut values = vec![1, 2, 3, 4, 5];
-
-    // SAFETY: get a raw pointer to the start of the vector, which is valid
-    // using `as_mut_ptr` as long as the vector exists and isn't reallocated.
-    let ptr = values.as_mut_ptr();
-    let len = values.len();
-
-    for i in 0..len {
-        unsafe {
-            // SAFETY: pointer arithmetic within the bounds of the vector.
-            let elem_ptr = ptr.add(i);
-
-            // SAFETY: dereference is safe because 0 <= i < len.
-            *elem_ptr *= 2;
-        }
-    }
-}
-```


### PR DESCRIPTION
Hey,

is this along the lines of what you had in mind for #123?

The added example is also at https://godbolt.org/z/EcYhz6rdK.

I thought that for the potential contribution to the learn unsafe Rust book chapter, pointer arithmetic could be linked to the Rust book's unsafe chapter by presenting pointer arithmetic as an additional action to the five "superpowers" provided by the unsafe keyword as they introduced [there](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#unsafe-superpowers).

If the approach here looks fine, I plan to continue working on code illustrations toward including the other aliasing and address keywords from the glossary.