### PR TITLE
Add proposed agenda for February consortium meeting

### DIFF
--- a/meetings/19-February-2025/agenda.md
+++ b/meetings/19-February-2025/agenda.md
@@ -1,0 +1,37 @@
+# Agenda for Safety Critical Rust Consortium Meeting, 19 February 2025, London UK
+
+The second meeting of the Safety Critical Rust Consortium meeting will be held on 19 February 2025 from 9 AM - 4 PM GMT/UTC in London, UK. Below is the proposed agenda. Additional suggestions welcome; please suggest a change or comment on the pull request associated with this agenda item.
+
+- Welcome (@JoelMarcey)
+- Consortium Logistics (@JoelMarcey)
+  - Membership Moving Forward
+  - Public information in the GitHub repo
+    - Names and Companies?
+  - Welcoming new members
+- Subcommittee Reports
+  - Coding Guidelines (@PLeVasseur)
+    - Status
+    - Current Work items
+    - Goals moving forward
+    - Other full consortium discussion items
+  - Tooling (@alexandruradovici)
+    - Status
+    - Current Work items
+    - Goals moving forward
+    - Other full consortium discussion items
+  - Form new subcommittees? (@JoelMarcey, all)
+- Lunch
+- Rust Specification Update and Discussion (@JoelMarcey)
+- Breakout groups (1 hour)
+  - Coding Guidelines (@PLeVasseur)
+  - Tooling (@alexandruradovici)
+  - Specification (@JoelMarcey)
+- Close (@JoelMarcey)
+  - Post-mortem
+    - What worked well?
+    - What can be improved?
+  - Next meeting
+    - RustConf?
+    
+
+

--- a/meetings/19-February-2025/agenda.md
+++ b/meetings/19-February-2025/agenda.md
@@ -20,7 +20,7 @@ The second meeting of the Safety Critical Rust Consortium meeting will be held o
     - Goals moving forward
     - Other full consortium discussion items
   - Form new subcommittees? (@JoelMarcey, all)
-- Lunch
+- Lunch (on your own)
 - Rust Specification Update and Discussion (@JoelMarcey)
 - Breakout groups (1 hour)
   - Coding Guidelines (@PLeVasseur)

--- a/meetings/19-February-2025/agenda.md
+++ b/meetings/19-February-2025/agenda.md
@@ -2,12 +2,13 @@
 
 The second meeting of the Safety Critical Rust Consortium meeting will be held on 19 February 2025 from 9 AM - 4 PM GMT/UTC in London, UK. Below is the proposed agenda. Additional suggestions welcome; please suggest a change or comment on the pull request associated with this agenda item.
 
-- Welcome (@JoelMarcey)
+- Welcome and Meeting Logistics (@JoelMarcey)
 - Consortium Logistics (@JoelMarcey)
   - Membership Moving Forward
   - Public information in the GitHub repo
     - Names and Companies?
   - Welcoming new members
+  - Production of Work
 - Subcommittee Reports
   - Coding Guidelines (@PLeVasseur)
     - Status
@@ -26,12 +27,12 @@ The second meeting of the Safety Critical Rust Consortium meeting will be held o
   - Coding Guidelines (@PLeVasseur)
   - Tooling (@alexandruradovici)
   - Specification (@JoelMarcey)
-- Close (@JoelMarcey)
+- Meeting Close (@JoelMarcey)
   - Post-mortem
     - What worked well?
     - What can be improved?
   - Next meeting
-    - RustConf?
+    - RustConf? Rust NL? Somewhere else?
     
 
 


### PR DESCRIPTION
This is a proposed agenda for the consortium meeting on 19 February 2025 in London, UK. If you have suggestions or additions, please comment.