### PR TITLE
Add members to the tooling subcommittee

### DIFF
--- a/subcommittee/tooling/members.md
+++ b/subcommittee/tooling/members.md
@@ -17,4 +17,5 @@
 - Oreste Bernardi (Infineon)
 - Tiago Manczak
 - Koppany Pazman (HighTec)
+- Manuel Hatzl
 - Alexandru Radovici (Moderator)

--- a/subcommittee/tooling/members.md
+++ b/subcommittee/tooling/members.md
@@ -18,4 +18,5 @@
 - Tiago Manczak
 - Koppany Pazman (HighTec)
 - Manuel Hatzl
+- Xander Cesari (Pictorus Inc)
 - Alexandru Radovici (Moderator)


### PR DESCRIPTION
This pull request adds Manuel Hatzl and Xander Cesari to the tooling subcommittee. It closes #163, closes #178.