### PR TITLE
London Meeting Action Item: Clarity on publicness of membership application

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.yml
+++ b/.github/ISSUE_TEMPLATE/membership.yml
@@ -19,6 +19,8 @@ body:
         If you do become a member of the consortium, you will be added to the consortium mailing list, which is currently the only non-public asset of the consortium at this point.
 
         Also, don't forget to join the consortium's [Zulip channel](https://rust-lang.zulipchat.com/#narrow/channel/445688-safety-critical-consortium).
+
+        > Note that the name, email address, and any company you provide will be public since GitHub issues are public. We do not use your information for any reason other than for membership purposes.
   - type: input
     id: Name
     attributes:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ See the full announcement [here](https://foundation.rust-lang.org/news/announcin
 
 Membership to the Safety Critical Rust Consortium is free. Please [file this GitHub issue](https://github.com/rustfoundation/safety-critical-rust-consortium/issues/new?assignees=joelmarcey&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml) to submit your membership application. 
 
+> Note: When you file the issue for membership, the name, email address and any company you provide will be public as GitHub issues are inherently public. We do not use your information for any reason other than membership purposes. 
+
 If for some reason you are unable or willing to file the application for membership via a GitHub issue, please send an email to `safety-critical-rust-consortium-contact [at] rustfoundation [dot] org`.
 
 Whether you become a member or not, you can join the consortium's [public Zulip channel](https://rust-lang.zulipchat.com/#narrow/channel/445688-safety-critical-consortium) to keep up with various happenings.


### PR DESCRIPTION
At the London meeting, we agreed to put a note in the README and issue template for memberhsip explictly letting folks know that some information they provide will be public via the GitHub issue.