### PR TITLE
Publish arewesafetycriticalyet.org from a folder

### DIFF
--- a/.github/workflows/arewesafetycriticalyet-org-test.yml
+++ b/.github/workflows/arewesafetycriticalyet-org-test.yml
@@ -54,7 +54,6 @@ jobs:
           # You can swap them out with your own user credentials.
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
-          keep_files: true
 
       - name: Publish the link in a PR comment
         run: |

--- a/.github/workflows/arewesafetycriticalyet-org.yml
+++ b/.github/workflows/arewesafetycriticalyet-org.yml
@@ -41,7 +41,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./arewesafetycriticalyet.org/build
-          # destination_dir: "docs"
+          destination_dir: "website"
           cname: arewesafetycriticalyet.org
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
@@ -50,4 +50,3 @@ jobs:
           # You can swap them out with your own user credentials.
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
-          keep_files: true

--- a/.github/workflows/arewesafetycriticalyet-org.yml
+++ b/.github/workflows/arewesafetycriticalyet-org.yml
@@ -41,7 +41,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./arewesafetycriticalyet.org/build
-          destination_dir: "website"
+          destination_dir: "/website/"
           cname: arewesafetycriticalyet.org
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:

--- a/.github/workflows/arewesafetycriticalyet-org.yml
+++ b/.github/workflows/arewesafetycriticalyet-org.yml
@@ -41,7 +41,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./arewesafetycriticalyet.org/build
-          destination_dir: "website"
+          destination_dir: "docs"
           cname: arewesafetycriticalyet.org
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:

--- a/.github/workflows/arewesafetycriticalyet-org.yml
+++ b/.github/workflows/arewesafetycriticalyet-org.yml
@@ -41,7 +41,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./arewesafetycriticalyet.org/build
-          destination_dir: "docs"
+          # destination_dir: "docs"
           cname: arewesafetycriticalyet.org
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
@@ -50,3 +50,4 @@ jobs:
           # You can swap them out with your own user credentials.
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          keep_files: true

--- a/arewesafetycriticalyet.org/docusaurus.config.ts
+++ b/arewesafetycriticalyet.org/docusaurus.config.ts
@@ -4,7 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
-const baseUrl = process.env.BASE_URL || '/';
+const baseUrl = process.env.BASE_URL || '/website';
 
 const config: Config = {
   title: 'Are We Safety Critical Yet?',


### PR DESCRIPTION
This pull request publishes the arewesafetycriticalyet.org website from the `docs` folder instead of the `website` folder.