### PR TITLE
arewesafetycriticalyet.org fix folder

### DIFF
--- a/.github/workflows/arewesafetycriticalyet-org.yml
+++ b/.github/workflows/arewesafetycriticalyet-org.yml
@@ -41,7 +41,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./arewesafetycriticalyet.org/build
-          destination_dir: "/website/"
+          destination_dir: "website/"
           cname: arewesafetycriticalyet.org
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:


### PR DESCRIPTION
This pull request fixes the folder from which arewesafetycritical.yet is displayed.