### PR TITLE
Tooling request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tooling_gap.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_gap.yml
@@ -1,0 +1,11 @@
+name: Tooling Request
+description: Identification of a gap in the safety-critical tooling ecosystem and request for a solution
+title: Tooling Request
+labels: ["tooling gap analysis", "tooling request"]
+assigness:
+  - joelmarcey, alexandruradovici
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to submit a tooling gap analysis.

--- a/.github/ISSUE_TEMPLATE/tooling_gap.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_gap.yml
@@ -14,25 +14,25 @@ body:
         ### crate/certifiable crate
         Use this category if you're interested in a crate, library, or a certifiable version of an existing crate.
 
-        Examples:
-        - Mathematical analysis crate
-        - Certifiable version of `heapless`
+        #### Examples:
+        * Mathematical analysis crate
+        * Certifiable version of `heapless`
 
         ### Internal Rust project tooling
         Use this category if the feature you're interested in is in a Rust Project managed piece of software.
         
-        Examples:
-        - rustc compiler flag
-        - Clippy lints
-        - Cargo extensions
+        #### Examples:
+        * rustc compiler flag
+        * Clippy lints
+        * Cargo extensions
 
         ### Developer tool
         This would be a development tool, an additional program used in the process of writing or verifying Rust.
 
-        Examples:
-        - Formal verification tool
-        - IDE
-        - Debugging tools
+        #### Examples:
+        * Formal verification tool
+        * IDE
+        * Debugging tools
   - type: dropdown
     id: tooling-type
     attributes:
@@ -55,13 +55,13 @@ body:
       label: What is a summary of the tooling gap you have identified?
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: gap_description
     attributes:
       label: Please elaborate on the process you or your organization is attempting and what the pain points are.
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: tool_suggestion
     attributes:
       label: Have you identified the tool or improvement that would directly solve your problem? Please list your suggestions here!

--- a/.github/ISSUE_TEMPLATE/tooling_gap.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_gap.yml
@@ -8,16 +8,62 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form to submit a tooling gap analysis.
+        ## Intention
+        If you or your organization is working in the Rust certification space, preferably directly developing certified software in Rust, and has identified a gap in tooling or process you can submit this form to bring this issue up to the consortium. We will attempt to bring these gaps to the correct organization that may be able to address it. This may be other organizations within the Rust Project or Rust Foundation, the open-source community, tooling vendor companies, or even members of the consortium.
+
+        ### crate/certifiable crate
+        Use this category if you're interested in a crate, library, or a certifiable version of an existing crate.
+
+        Examples:
+        - Mathematical analysis crate
+        - Certifiable version of `heapless`
+
+        ### Internal Rust project tooling
+        Use this category if the feature you're interested in is in a Rust Project managed piece of software.
+        
+        Examples:
+        - rustc compiler flag
+        - Clippy lints
+        - Cargo extensions
+
+        ### Developer tool
+        This would be a development tool, an additional program used in the process of writing or verifying Rust.
+
+        Examples:
+        - Formal verification tool
+        - IDE
+        - Debugging tools
   - type: dropdown
     id: tooling-type
     attributes:
       label: What type of tool are you proposing?
       description: Including
       options:
-        - 'crate'
-        - 'Internal Rust project tooling (clippy, cargo, etc)'
+        - 'crate/certifiable crate'
+        - 'Internal Rust project tooling (rustc, clippy, cargo, etc)'
         - 'Developer tool (IDE, analysis tool, etc)'
       default: 1
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to submit a tooling gap analysis.
+  - type: input
+    id: title
+    attributes:
+      label: What is a summary of the tooling gap you have identified?
+    validations:
+      required: true
+  - type: input
+    id: gap_description
+    attributes:
+      label: Please elaborate on the process you or your organization is attempting and what the pain points are.
+    validations:
+      required: true
+  - type: input
+    id: tool_suggestion
+    attributes:
+      label: Have you identified the tool or improvement that would directly solve your problem? Please list your suggestions here!
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/tooling_gap.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_gap.yml
@@ -8,8 +8,29 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Intention
+        ## Process Gap
         If you or your organization is working in the Rust certification space, preferably directly developing certified software in Rust, and has identified a gap in tooling or process you can submit this form to bring this issue up to the consortium. We will attempt to bring these gaps to the correct organization that may be able to address it. This may be other organizations within the Rust Project or Rust Foundation, the open-source community, tooling vendor companies, or even members of the consortium.
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to submit a tooling gap analysis.
+  - type: input
+    id: title
+    attributes:
+      label: What is a summary of the tooling gap you have identified?
+    validations:
+      required: true
+  - type: textarea
+    id: gap_description
+    attributes:
+      label: Please elaborate on the process you or your organization is attempting and what the pain points are.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Tooling Suggestion
+        If you think you've identified exactly or approximately what tool would solve this gap please share it here.
 
         ### crate/certifiable crate
         Use this category if you're interested in a crate, library, or a certifiable version of an existing crate.
@@ -44,23 +65,7 @@ body:
         - 'Developer tool (IDE, analysis tool, etc)'
       default: 1
     validations:
-      required: true
-  - type: markdown
-    attributes:
-      value: |
-        Use this form to submit a tooling gap analysis.
-  - type: input
-    id: title
-    attributes:
-      label: What is a summary of the tooling gap you have identified?
-    validations:
-      required: true
-  - type: textarea
-    id: gap_description
-    attributes:
-      label: Please elaborate on the process you or your organization is attempting and what the pain points are.
-    validations:
-      required: true
+      required: false
   - type: textarea
     id: tool_suggestion
     attributes:

--- a/.github/ISSUE_TEMPLATE/tooling_gap.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_gap.yml
@@ -2,10 +2,22 @@ name: Tooling Request
 description: Identification of a gap in the safety-critical tooling ecosystem and request for a solution
 title: Tooling Request
 labels: ["tooling gap analysis", "tooling request"]
-assigness:
+assignees:
   - joelmarcey, alexandruradovici
 body:
   - type: markdown
     attributes:
       value: |
         Use this form to submit a tooling gap analysis.
+  - type: dropdown
+    id: tooling-type
+    attributes:
+      label: What type of tool are you proposing?
+      description: Including
+      options:
+        - 'crate'
+        - 'Internal Rust project tooling (clippy, cargo, etc)'
+        - 'Developer tool (IDE, analysis tool, etc)'
+      default: 1
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/tooling_gap.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_gap.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Process Gap
+        ## Process/Tooling Gap
         If you or your organization is working in the Rust certification space, preferably directly developing certified software in Rust, and has identified a gap in the development process you can submit this form to bring this issue up to the consortium. We will attempt to bring these gaps to the correct organization that may be able to address it, usually through the development of new tools or the modification of existing tooling. This may be other organizations within the Rust Project or Rust Foundation, the open-source community, tooling vendor companies, or even members of the consortium.
 
         Optionally, if you have a good idea of exactly what tool or tool modification would close this process gap we invite you to describe the tool.
@@ -26,7 +26,7 @@ body:
       placeholder: "Example: When clippy lints are generating errors or warning there is terminal content to be printed but when all clippy lints are passing or failing there's no way to generate traceability documentation indicating that the code passed the built-in checks. This would be useful for certification and code auditing."
     validations:
       required: true
-  - type: textarea
+  - type: input
     id: specification
     attributes:
       label: What certification/specification does this process pertain to (if any)?
@@ -71,7 +71,7 @@ body:
   - type: textarea
     id: tool_suggestion
     attributes:
-      label: Have you identified the tool or improvement that would directly solve your problem? Please list your suggestions here!
+      label: What tool or tool improvement would solve this process gap?
       placeholder: "Example: a cargo flag that would generate a log file of all clippy lints that ran and their result"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/tooling_gap.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_gap.yml
@@ -15,24 +15,24 @@ body:
         Use this category if you're interested in a crate, library, or a certifiable version of an existing crate.
 
         #### Examples:
-        * Mathematical analysis crate
-        * Certifiable version of `heapless`
+          * Mathematical analysis crate
+          * Certifiable version of `heapless`
 
         ### Internal Rust project tooling
         Use this category if the feature you're interested in is in a Rust Project managed piece of software.
         
         #### Examples:
-        * rustc compiler flag
-        * Clippy lints
-        * Cargo extensions
+          * rustc compiler flag
+          * Clippy lints
+          * Cargo extensions
 
         ### Developer tool
         This would be a development tool, an additional program used in the process of writing or verifying Rust.
 
         #### Examples:
-        * Formal verification tool
-        * IDE
-        * Debugging tools
+          * Formal verification tool
+          * IDE
+          * Debugging tools
   - type: dropdown
     id: tooling-type
     attributes:

--- a/.github/ISSUE_TEMPLATE/tooling_gap.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_gap.yml
@@ -1,4 +1,4 @@
-name: Tooling Request
+name: Missing Tool/Process
 description: Identification of a gap in the safety-critical tooling ecosystem and request for a solution
 title: Tooling Request
 labels: ["tooling gap analysis", "tooling request"]
@@ -9,51 +9,52 @@ body:
     attributes:
       value: |
         ## Process Gap
-        If you or your organization is working in the Rust certification space, preferably directly developing certified software in Rust, and has identified a gap in tooling or process you can submit this form to bring this issue up to the consortium. We will attempt to bring these gaps to the correct organization that may be able to address it. This may be other organizations within the Rust Project or Rust Foundation, the open-source community, tooling vendor companies, or even members of the consortium.
-  - type: markdown
-    attributes:
-      value: |
-        Use this form to submit a tooling gap analysis.
+        If you or your organization is working in the Rust certification space, preferably directly developing certified software in Rust, and has identified a gap in the development process you can submit this form to bring this issue up to the consortium. We will attempt to bring these gaps to the correct organization that may be able to address it, usually through the development of new tools or the modification of existing tooling. This may be other organizations within the Rust Project or Rust Foundation, the open-source community, tooling vendor companies, or even members of the consortium.
+
+        Optionally, if you have a good idea of exactly what tool or tool modification would close this process gap we invite you to describe the tool.
   - type: input
     id: title
     attributes:
-      label: What is a summary of the tooling gap you have identified?
+      label: What is a brief summary of the gap you have identified?
+      placeholder: "Example: no documentation is generated when all clippy lints pass."
     validations:
       required: true
   - type: textarea
     id: gap_description
     attributes:
       label: Please elaborate on the process you or your organization is attempting and what the pain points are.
+      placeholder: "Example: When clippy lints are generating errors or warning there is terminal content to be printed but when all clippy lints are passing or failing there's no way to generate traceability documentation indicating that the code passed the built-in checks. This would be useful for certification and code auditing."
     validations:
       required: true
+  - type: textarea
+    id: specification
+    attributes:
+      label: What certification/specification does this process pertain to (if any)?
+      placeholder: "Example: ISO-26262 ASIL-D"
   - type: markdown
     attributes:
       value: |
         ## Tooling Suggestion
-        If you think you've identified exactly or approximately what tool would solve this gap please share it here.
-
+        Optionally, if you've identified exactly or approximately what tool would solve this gap please share more details here.
+  - type: markdown
+    attributes:
+      value: |
         ### crate/certifiable crate
         Use this category if you're interested in a crate, library, or a certifiable version of an existing crate.
 
-        #### Examples:
-          * Mathematical analysis crate
-          * Certifiable version of `heapless`
+        *Examples: Mathematical analysis crate, Certifiable version of `heapless`*
 
         ### Internal Rust project tooling
         Use this category if the feature you're interested in is in a Rust Project managed piece of software.
-        
-        #### Examples:
-          * rustc compiler flag
-          * Clippy lints
-          * Cargo extensions
+
+        *Examples: rustc compiler flag, clippy lints, Cargo extensions*
 
         ### Developer tool
         This would be a development tool, an additional program used in the process of writing or verifying Rust.
 
-        #### Examples:
-          * Formal verification tool
-          * IDE
-          * Debugging tools
+        *Examples: Formal verification tool, IDE, Debugging tools*
+
+        ### Other
   - type: dropdown
     id: tooling-type
     attributes:
@@ -63,6 +64,7 @@ body:
         - 'crate/certifiable crate'
         - 'Internal Rust project tooling (rustc, clippy, cargo, etc)'
         - 'Developer tool (IDE, analysis tool, etc)'
+        - 'Other'
       default: 1
     validations:
       required: false
@@ -70,5 +72,6 @@ body:
     id: tool_suggestion
     attributes:
       label: Have you identified the tool or improvement that would directly solve your problem? Please list your suggestions here!
+      placeholder: "Example: a cargo flag that would generate a log file of all clippy lints that ran and their result"
     validations:
       required: false


### PR DESCRIPTION
This is an idea I had while sitting at the meeting in Utrecht. A member had mentioned that they were limited by a very specific and comparatively minor limitation with current Rust tooling, specifically that when their Rust code is passing all clippy lints there's no documentation generated of the code compliance to feed into the internal or external audit process. This seemed like a pretty minor issue to bring to the cargo/clippy teams now that it was identified.

This GitHub issue template is an attempt at capturing issues that safety-critical Rust users are finding with their tooling. The consortium can then bring these issues to the correct stakeholder. For example, issues with Rust projects (cargo, clippy, rustc, etc) can be brought directly to the maintainers. Issues that can be solved by commercial software companies working in the space can be broadcast within the consortium member companies. And lastly, issues that could be solved by the open-source community could be advertised across Rust channels.

This will likely be discussed at an upcoming Tooling Subcommittee meeting (attn @alexandruradovici) but this draft PR is to get some visibility and discussion going.