### PR TITLE
Migrate notes templates. Backlink to tips on how to take notes from notes templates.

### DIFF
--- a/docs/full-consortium-meeting-notes-template.md
+++ b/docs/full-consortium-meeting-notes-template.md
@@ -1,0 +1,41 @@
+# Safety-Critical Rust Consortium Meeting on \<date\> @ \<time\>
+
+| Search Key | Description |
+| :---- | :---- |
+| \[todo\] | Action Item |
+| \[decision\] | Something decided on |
+| \[important\] | Key information |
+
+## Agenda
+
+1. 
+
+## Check-in area
+
+**Please add your name, and an emoji that describes your day.**
+
+* 
+
+**Notetaker:**
+
+* 
+
+For tips on how we take notes in the Safety-Critical Rust Consortium, please see the [Meeting Notetaker Role](https://github.com/rustfoundation/safety-critical-rust-consortium/blob/main/docs/notetaker-role.md) doc.
+
+## Housekeeping section
+
+* 
+
+## Tasks
+
+* 
+
+## Meeting Minutes
+
+* 
+
+## Material
+
+Any material to read before the meeting should be included here.
+
+* 

--- a/docs/notetaker-role.md
+++ b/docs/notetaker-role.md
@@ -1,4 +1,4 @@
-# Meeting Notetaker
+# Meeting Notetaker Role
 
 Thank you for taking notes for a session! The following are the steps you will follow.
 
@@ -6,7 +6,10 @@ Reminder that we follow the consortium-wide agreed meeting policies. Please refe
 
 ## Take meeting notes live in a Google Docs document
 
-A template for meeting minutes is shared [here](https://docs.google.com/document/d/1vx_Ih9DRXQrHU_pP_uUZWjqvMKzzAR6EkS5lINzT4bA/edit?usp=sharing) should you need it.
+Start with the right meeting notes template:
+
+* [Full consortium meeting notes template](full-consortium-meeting-notes-template.md)
+* [Subcommittee meeting notes template](subcommittee-meeting-notes-template.md)
 
 During the meeting you'll take meeting minutes of participants' discussion in a Google Docs document that will be shared as the meeting begins.
 

--- a/docs/subcommittee-meeting-notes-template.md
+++ b/docs/subcommittee-meeting-notes-template.md
@@ -1,0 +1,41 @@
+# \<Foo\> Subcommittee Meeting on \<date\> @ \<time\>
+
+| Search Key | Description |
+| :---- | :---- |
+| \[todo\] | Action Item |
+| \[decision\] | Something decided on |
+| \[important\] | Key information |
+
+## Agenda
+
+1. 
+
+## Check-in area
+
+**Please add your name, and an emoji that describes your day.**
+
+* 
+
+**Notetaker:**
+
+* 
+
+For tips on how we take notes in the Safety-Critical Rust Consortium, please see the [Meeting Notetaker Role](https://github.com/rustfoundation/safety-critical-rust-consortium/blob/main/docs/notetaker-role.md) doc.
+
+## Housekeeping section
+
+* 
+
+## Tasks
+
+* 
+
+## Meeting Minutes
+
+* 
+
+## Material
+
+Any material to read before the meeting should be included here.
+
+* 


### PR DESCRIPTION
Migrate meeting note templates to repo. Backlink from meeting note template to the note taker role doc.