### PR TITLE
Improve link visibility for headings in light mode

### DIFF
--- a/arewesafetycriticalyet.org/src/css/custom.css
+++ b/arewesafetycriticalyet.org/src/css/custom.css
@@ -28,3 +28,14 @@
   --ifm-color-primary-lightest: #e2edff;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+/* Improve visibility of links inside coding_guidelines documentation */
+.markdown a {
+  color: var(--ifm-color-primary);
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.markdown a:hover {
+  text-decoration: underline;
+  opacity: 0.85;
+}


### PR DESCRIPTION
On the mission page (`coding_guidelines/mission`), section headings like "SAE" and "SAfEr Rust Task Force" are links, but are not visually distinguishable from regular text in light mode.

- Currently, the links are styled similarly to regular text and only reveal that they are clickable when the user hovers over them.
- This PR improves link visibility by adding clearer styling (color + underline) to heading links in light mode while preserving the existing behavior in dark mode.
---

## Before
(Headings appear as regular text)

![Before Screenshot](https://github.com/user-attachments/assets/71722a1b-1f38-4209-880e-40d26bcdf859)

## After
(Headings are clearly distinguishable as links)
![After Screenshot](https://github.com/user-attachments/assets/510453e9-661b-41c2-9486-5a0298385c28)

Closes #573 

