### PR TITLE
publish the meeting minutes to arewesafetycriticalyet.org

### DIFF
--- a/arewesafetycriticalyet.org/docs/coding_guidelines/meetings
+++ b/arewesafetycriticalyet.org/docs/coding_guidelines/meetings
@@ -1,0 +1,1 @@
+../../../subcommittee/coding-guidelines/meetings

--- a/arewesafetycriticalyet.org/docs/coding_guidelines/members.md
+++ b/arewesafetycriticalyet.org/docs/coding_guidelines/members.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Members
 
 | Member Name                | Affiliation                            | Role                        | GitHub Username    |
@@ -67,4 +70,3 @@
 | Andreas Weis               | ekxide IO GmbH                         | Producer                    | @ComicSansMS       |
 | Arshad Mahmood             | SpinorML                               | Producer                    | @arshadm           |
 | Jason Newcomb              | Rust Project - Clippy Team             | Producer                    | @Jarcho            |
-

--- a/arewesafetycriticalyet.org/docs/coding_guidelines/mission.md
+++ b/arewesafetycriticalyet.org/docs/coding_guidelines/mission.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Mission Statement
 
 Develop a community-vetted coding guideline for Rust in safety-critical applications. A living document that is updated as features are added to Rust and we learn more by doing.

--- a/arewesafetycriticalyet.org/docs/liaison/meetings
+++ b/arewesafetycriticalyet.org/docs/liaison/meetings
@@ -1,0 +1,1 @@
+../../../subcommittee/liaison/meetings

--- a/arewesafetycriticalyet.org/docs/liaison/members.md
+++ b/arewesafetycriticalyet.org/docs/liaison/members.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Members
 
 | Member Name             | Affiliation                                         | GitHub Username    |

--- a/arewesafetycriticalyet.org/docs/main/iso26262.md
+++ b/arewesafetycriticalyet.org/docs/main/iso26262.md
@@ -23,7 +23,7 @@ Table 1 — Topics to be covered by modelling and coding guidelines
 | ID | Method | Solution: Rust Native or Tool | Readiness |
 | :--- | :--- | :--- | :--- |
 | **1a** | Enforcement of low complexity | (Process) **statically enforceable** by clippy tool e.g. cyclomatic_complexity | 🟢 |
-| **1b** | Use of language subsets | (Language) **coding guidelines** (are in progress by Subcommittee), need to be developed individually | 🟡 |
+| **1b** | Use of language subsets | (Language) coding guidelines (are in progress by Subcommittee), need to be developed individually | 🟡 |
 | **1c** | Enforcement of strong typing | (Language) **inherent** feature of Rust | 🟢 |
 | **1d** | Use of defensive implementation techniques | (Architecture) **encouraged** by use of Types `Option`/`Result`,`assert!`/`panic!` macros, exhaustive match, mandatory bounds checking on array/slice access, and explicit per-operation overflow handling available via checked_*/saturating_* methods (can also be allowed implicitly by configuring) | 🟢 |
 | **1e** | Use of well-trusted design principles | (Architecture) **encouraged** by Rust inherent features like encapsulation and RAII by default | 🟢 |

--- a/arewesafetycriticalyet.org/docs/tooling/meetings
+++ b/arewesafetycriticalyet.org/docs/tooling/meetings
@@ -1,0 +1,1 @@
+../../../subcommittee/tooling/meetings

--- a/arewesafetycriticalyet.org/docs/tooling/members.md
+++ b/arewesafetycriticalyet.org/docs/tooling/members.md
@@ -1,5 +1,5 @@
 ---
-position: 2
+sidebar_position: 2
 ---
 
 # Members
@@ -41,4 +41,8 @@ position: 2
 - Jonatan Hatakeyama Zeidler (Brainlab SE)
 - Stefan Akatyschew
 - Zalán Bálint Lévai
+- Máté János Kovács
+- Kartik Ohlan
+- Everton Oriente
+- Adam Milner (Waabi)
 - Alexandru Radovici (Moderator)

--- a/arewesafetycriticalyet.org/docs/tooling/open-topics.md
+++ b/arewesafetycriticalyet.org/docs/tooling/open-topics.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 5
+---
 # Open Topics
 
 This page lists open topics related to Rust tooling for safety critical domains.
@@ -6,7 +9,7 @@ This page lists open topics related to Rust tooling for safety critical domains.
 
   No generally applicable tool exists to inject faults in Rust projects during testing.
 
-- **Coding Guideline:**
+- Coding Guideline:
 
   No official Rust coding guidelines currently exist, so no tool can enforce them.
   The Coding Guidelines subcommittee is actively working on defining Rust coding guidelines.

--- a/arewesafetycriticalyet.org/docs/tooling/rfc-tools-review.md
+++ b/arewesafetycriticalyet.org/docs/tooling/rfc-tools-review.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 4
+---
 # Tools List Maintenance Flows
 
 This section defines how the tools list is managed by the tooling subcommittee.

--- a/arewesafetycriticalyet.org/docs/tooling/statement.md
+++ b/arewesafetycriticalyet.org/docs/tooling/statement.md
@@ -1,5 +1,5 @@
 ---
-position: 1
+sidebar_position: 1
 ---
 # Mission Statement
 

--- a/arewesafetycriticalyet.org/docs/tooling/tools-list.mdx
+++ b/arewesafetycriticalyet.org/docs/tooling/tools-list.mdx
@@ -1,5 +1,5 @@
 ---
-position: 3
+sidebar_position: 3
 ---
 
 import ToolsList from '@site/src/components/ToolsList';

--- a/arewesafetycriticalyet.org/docusaurus.config.ts
+++ b/arewesafetycriticalyet.org/docusaurus.config.ts
@@ -1,59 +1,60 @@
-import { themes as prismThemes } from 'prism-react-renderer';
-import type { Config } from '@docusaurus/types';
-import type * as Preset from '@docusaurus/preset-classic';
+import { themes as prismThemes } from "prism-react-renderer";
+import type { Config } from "@docusaurus/types";
+import type * as Preset from "@docusaurus/preset-classic";
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
-const baseUrl = process.env.BASE_URL || '/';
+const baseUrl = process.env.BASE_URL || "/";
 
 const config: Config = {
-  title: 'Are We Safety Critical Yet?',
-  tagline: 'Tracking Rust\'s readiness for safety-critical development across industry standards.',
-  favicon: 'img/favicon.ico',
+  title: "Are We Safety Critical Yet?",
+  tagline:
+    "Tracking Rust's readiness for safety-critical development across industry standards.",
+  favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: 'https://your-docusaurus-site.example.com',
+  url: "https://your-docusaurus-site.example.com",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: "/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'facebook', // Usually your GitHub org/user name.
-  projectName: 'docusaurus', // Usually your repo name.
+  organizationName: "facebook", // Usually your GitHub org/user name.
+  projectName: "docusaurus", // Usually your repo name.
 
-  onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: "throw",
+  onBrokenMarkdownLinks: "warn",
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en'],
+    defaultLocale: "en",
+    locales: ["en"],
   },
 
   markdown: {
     mermaid: true,
   },
 
-  themes: ['@docusaurus/theme-mermaid'],
+  themes: ["@docusaurus/theme-mermaid"],
 
   presets: [
     [
-      'classic',
+      "classic",
       {
         docs: {
-          path: 'docs/main',
-          sidebarPath: './docs/sidebars.ts',
+          path: "docs/main",
+          sidebarPath: "./docs/sidebars.ts",
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/rustfoundation/safety-critical-rust-consortium/tree/main/arewesafetycriticalyet.org',
+            "https://github.com/rustfoundation/safety-critical-rust-consortium/tree/main/arewesafetycriticalyet.org",
         },
         blog: false,
         theme: {
-          customCss: './src/css/custom.css',
+          customCss: "./src/css/custom.css",
         },
       } satisfies Preset.Options,
     ],
@@ -61,84 +62,96 @@ const config: Config = {
 
   plugins: [
     [
-      '@docusaurus/plugin-content-docs',
+      "@docusaurus/plugin-content-docs",
       {
-        id: 'coding_guidelines',
-        path: 'docs/coding_guidelines',
-        routeBasePath: 'coding_guidelines',
-        sidebarPath: './docs/sidebarsCodingGuidelines.ts',
+        id: "coding_guidelines",
+        path: "docs/coding_guidelines",
+        routeBasePath: "coding_guidelines",
+        sidebarPath: "./docs/sidebarsCodingGuidelines.ts",
         // ... other options
       },
     ],
     [
-      '@docusaurus/plugin-content-docs',
+      "@docusaurus/plugin-content-docs",
       {
-        id: 'tooling',
-        path: 'docs/tooling',
-        routeBasePath: 'tooling',
-        sidebarPath: './docs/sidebarsTooling.ts',
+        id: "tooling",
+        path: "docs/tooling",
+        routeBasePath: "tooling",
+        sidebarPath: "./docs/sidebarsTooling.ts",
         // ... other options
       },
     ],
     [
-      '@docusaurus/plugin-content-docs',
+      "@docusaurus/plugin-content-docs",
       {
-        id: 'liaison',
-        path: 'docs/liaison',
-        routeBasePath: 'liaison',
-        sidebarPath: './docs/sidebarsLiaison.ts',
+        id: "liaison",
+        path: "docs/liaison",
+        routeBasePath: "liaison",
+        sidebarPath: "./docs/sidebarsLiaison.ts",
         // ... other options
       },
-    ]
+    ],
+    function webpackConfigPlugin() {
+      return {
+        name: "custom-webpack-plugin",
+        configureWebpack() {
+          return {
+            resolve: {
+              symlinks: false,
+            },
+          };
+        },
+      };
+    },
   ],
 
   themeConfig: {
     // Replace with your project's social card
-    image: 'img/docusaurus-social-card.jpg',
+    image: "img/docusaurus-social-card.jpg",
     navbar: {
-      title: 'Are We Safety Critical Yet?',
+      title: "Are We Safety Critical Yet?",
       logo: {
-        alt: 'The Safety Critical Rust Logo',
-        src: 'img/rust_safety_logo.png',
+        alt: "The Safety Critical Rust Logo",
+        src: "img/rust_safety_logo.png",
       },
       items: [
         {
-          type: 'docSidebar',
-          docsPluginId: 'coding_guidelines',
-          sidebarId: 'codingGuidelinesSidebar',
-          position: 'left',
-          label: 'Coding Guidelines',
+          type: "docSidebar",
+          docsPluginId: "coding_guidelines",
+          sidebarId: "codingGuidelinesSidebar",
+          position: "left",
+          label: "Coding Guidelines",
         },
         {
-          type: 'docSidebar',
-          docsPluginId: 'tooling',
-          sidebarId: 'toolingSidebar',
-          position: 'left',
-          label: 'Tooling',
+          type: "docSidebar",
+          docsPluginId: "tooling",
+          sidebarId: "toolingSidebar",
+          position: "left",
+          label: "Tooling",
         },
         {
-          type: 'docSidebar',
-          docsPluginId: 'liaison',
-          sidebarId: 'liaisonSidebar',
-          position: 'left',
-          label: 'Liaison',
+          type: "docSidebar",
+          docsPluginId: "liaison",
+          sidebarId: "liaisonSidebar",
+          position: "left",
+          label: "Liaison",
         },
         {
-          href: 'https://github.com/rustfoundation/safety-critical-rust-consortium',
-          label: 'GitHub',
-          position: 'right',
+          href: "https://github.com/rustfoundation/safety-critical-rust-consortium",
+          label: "GitHub",
+          position: "right",
         },
       ],
     },
     footer: {
-      style: 'dark',
+      style: "dark",
       links: [
         {
-          title: 'Community',
+          title: "Community",
           items: [
             {
-              label: 'This site is powered through Netlify',
-              href: 'https://netlify.com',
+              label: "This site is powered through Netlify",
+              href: "https://netlify.com",
             },
           ],
         },

--- a/meetings/2025-02-19/summary.md
+++ b/meetings/2025-02-19/summary.md
@@ -4,7 +4,7 @@
   rules apply.
 - **Membership Status:** Currently 109 members; discussion on maintaining a
   low-friction join process while continuing to vet new member legitimacy.
-- **Coding Guidelines:** Focus on drafting guidelines, starter project of “Learn
+- Coding Guidelines: Focus on drafting guidelines, starter project of “Learn
   Unsafe Rust” chapters contribution, aliged on standards mapping as an appendix
   item, north star to be safe use of Rust, useful patterns for eliminating
   safety issues, with standards compliance as a second-order effect of following

--- a/meetings/2025-05-15/summary.md
+++ b/meetings/2025-05-15/summary.md
@@ -3,9 +3,9 @@
 - **Website**: https://arewesafetycriticalyet.org is live. Now need to add more content.
 - **Survey results**: Reviewed [survey results](https://docs.google.com/presentation/d/1bUCP6hYtyLq3jeOgxWRv-El1Babite7o9QNXVpjdgr0/edit?slide=id.g350e3d6870f_0_25#slide=id.g350e3d6870f_0_25). 200+ responses. Key insights particularly around adoption where coding guidelines, materials for making the case, certified compilers and toolings were the main items of need.
 - **Rust specification**: FLS is now part of the Rust project. Working on how to synchronize the FLS and the Reference. RFCs won't yet be blocked on FLS changes, but maybe stabilization could in the future.
-- **Coding guidelines**: Some coding guidelines are landing. Long-term could see coding guidelines as part of a clippy lint of sorts. Aligning with MISRA.
+- Coding guidelines: Some coding guidelines are landing. Long-term could see coding guidelines as part of a clippy lint of sorts. Aligning with MISRA.
 - **Tooling**: Need to think about the bar on how tools are added to tooling recommendations list. 
 - **Liaison**: The team has specific organization contact points for upstreaming and collaboration including AUTOSAR and WG23.
 - **Next meeting**: No alignment on when the next meeting should be and where. A poll will be created to try to finalize.
 - **MISRA vs. CERT**: MISRA has a deviation process. CERT rarely has a deviation process. Need to decide whether to go more towards a set of rules (like MISRA) or an iterative improvement process (like CERT), or find a more middle ground (if possible).
-- **Streamlining Qualification**: Rust reduces mistakes. Qualification should be easier. Pooling resources to help.  
+- **Streamlining Qualification**: Rust reduces mistakes. Qualification should be easier. Pooling resources to help.

--- a/subcommittee/coding-guidelines/meetings/2024-10-22/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2024-10-22/minutes.md
@@ -60,10 +60,10 @@ Joel Marcey
     * Understanding Rust and/or safety critical  
   * How are the guidelines enforced?  
   * (These are _not_ presented here due to decision to rework these in 2024-11-11 meeting)
-* [**Mission Statement**](../../mission-statement.md)
+* [**Mission Statement**](https://github.com/rustfoundation/safety-critical-rust-consortium/tree/main/subcommittee/coding-guidelines/mission-statement.md)
   * Develop a community-vetted coding guideline for Rust in safety-critical applications  
   * Provide feedback offline  
-* [**Unsafe coding guidelines proposal**](../../initiatives/safe-use-of-unsafe-guidelines/safe-use-of-unsafe-guidelines-proposal.md)
+* [**Unsafe coding guidelines proposal**](https://github.com/rustfoundation/safety-critical-rust-consortium/tree/main/subcommittee/coding-guidelines/initiatives/safe-use-of-unsafe-guidelines/safe-use-of-unsafe-guidelines-proposal.md)
   * How does the `unsafe` keyword and usage fit into our coding guidelines?  
   * This will be the first item of output by the subcommittee  
   * Peter \- check and see what we can use out of JAE1020  
@@ -84,4 +84,3 @@ Joel Marcey
 ## Material
 
 Any material to read before the meeting should be included here.
-

--- a/subcommittee/coding-guidelines/meetings/2024-11-19/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2024-11-19/minutes.md
@@ -3,12 +3,12 @@
 ## Agenda
 
 0. Meeting recordings / transcriptions - Live discussion
-1. Acceptance of [Previous Meeting Minutes](../2024-November-05/minutes.md)
+1. Acceptance of [Previous Meeting Minutes](../2024-11-05/minutes.md)
 2. Shift meeting time 2 hours earlier to accommodate Asia participants (Pete LeVasseur)
 3. Contributor Expectations - Approval (Pete LeVasseur)
 4. Safe Usage of Unsafe Guidelines - Check-in (Pete LeVasseur)
   * [Learn `unsafe` Rust](https://github.com/google/learn_unsafe_rust) - Offline Review & Q&A
-  * [Examples of unsafe patterns](../../initiatives/safe-use-of-unsafe-guidelines/unsafe-example-usage.md) - Chapter writeup
+  * [Examples of unsafe patterns](https://github.com/rustfoundation/safety-critical-rust-consortium/tree/main/subcommittee/coding-guidelines/initiatives/safe-use-of-unsafe-guidelines/unsafe-example-usage.md) - Chapter writeup
 5. MISRA + Rust (Alex Celeste)
 6. Round table
 

--- a/subcommittee/coding-guidelines/meetings/2025-03-26/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-03-26/minutes.md
@@ -44,7 +44,7 @@ Supplemental material to the agenda can be found on the [GitHub repo](https://gi
 * Andrew Herridge 😀
 * Lukas Wirth 🙁
 * Espen Albrektsen 🙂
-* Markus Hosch <_<
+* Markus Hosch
 * Enow Scott 🙂
 * Achim Kriso 🙂
 * Koppany Pazman

--- a/subcommittee/coding-guidelines/meetings/2025-03-26/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-03-26/minutes.md
@@ -44,7 +44,7 @@ Supplemental material to the agenda can be found on the [GitHub repo](https://gi
 * Andrew Herridge 😀
 * Lukas Wirth 🙁
 * Espen Albrektsen 🙂
-* Markus Hosch
+* Markus Hosch \<_\<
 * Enow Scott 🙂
 * Achim Kriso 🙂
 * Koppany Pazman

--- a/subcommittee/coding-guidelines/meetings/2025-06-25/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-06-25/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-06-25 @ 15:00 UTC / 16:00 BST / 11:00 EDT**
+# Coding Guidelines Subcommittee Meeting on 2025-06-25 @ 15:00 UTC / 16:00 BST / 11:00 EDT
 
 [Conversion](https://www.worldtimebuddy.com/?qm=1&lid=5,14,8,12&h=5&date=2025-6-25&sln=11-12&hf=1) between common time zones of attendees.
 
@@ -76,4 +76,3 @@ Any material to read before the meeting should be included here.
 ### **GitHub Project Board for Work Items**
 
 * [Work Item Board](https://github.com/orgs/rustfoundation/projects/1)
-

--- a/subcommittee/coding-guidelines/meetings/2025-07-09/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-07-09/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-07-09 @ 0800 BST / 0900 CEST / 2025-07-09 @ 1600 JST**
+# Coding Guidelines Subcommittee Meeting on 2025-07-09 @ 0800 BST / 0900 CEST / 2025-07-09 @ 1600 JST
 
 [Conversion](https://www.worldtimebuddy.com/?qm=1&lid=14,12,1850147&h=14&date=2025-7-9&sln=8-9&hf=1) between common time zones of attendees.
 
@@ -81,4 +81,3 @@ Any material to read before the meeting should be included here.
 ### **GitHub Project Board for Work Items**
 
 * [Work Item Board](https://github.com/orgs/rustfoundation/projects/1)
-

--- a/subcommittee/coding-guidelines/meetings/2025-07-16/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-07-16/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-07-16 @ 1600 BST / 1700 CEST / 1100 EDT / 2025-07-17 @ 0000 JST**
+# Coding Guidelines Subcommittee Meeting on 2025-07-16 @ 1600 BST / 1700 CEST / 1100 EDT / 2025-07-17 @ 0000 JST
 
 [Conversion](https://www.worldtimebuddy.com/?qm=1&lid=14,12,5,1850147&h=14&date=2025-7-16&sln=16-17&hf=1) between common time zones of attendees.
 
@@ -104,4 +104,3 @@ Any material to read before the meeting should be included here.
 ### **GitHub Project Board for Work Items**
 
 * [Work Item Board](https://github.com/orgs/rustfoundation/projects/1)
-

--- a/subcommittee/coding-guidelines/meetings/2025-07-22/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-07-22/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-07-22 @ 20:00 EST / 2025-07-23 @ 09:00 JST**
+# Coding Guidelines Subcommittee Meeting on 2025-07-22 @ 20:00 EST / 2025-07-23 @ 09:00 JST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,1880252,8&h=5&date=2025-7-22&sln=20-21&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/coding-guidelines/meetings/2025-07-30/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-07-30/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-07-30 @ 0800 BST / 0900 CEST / 1600 JST**
+# Coding Guidelines Subcommittee Meeting on 2025-07-30 @ 0800 BST / 0900 CEST / 1600 JST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=14,12,1850147&h=14&date=2025-7-30&sln=8-9&hf=1) to meeting time in common time zones.
 
@@ -93,4 +93,3 @@ Any material to read before the meeting should be included here.
 ### **GitHub Project Board for Work Items**
 
 * [Work Item Board](https://github.com/orgs/rustfoundation/projects/1)
-

--- a/subcommittee/coding-guidelines/meetings/2025-08-06/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-08-06/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-08-06 @ 1100 EDT / 1700 CEST**
+# Coding Guidelines Subcommittee Meeting on 2025-08-06 @ 1100 EDT / 1700 CEST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,1880252,8,6&h=5&date=2025-8-6&sln=11-12&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/coding-guidelines/meetings/2025-08-12/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-08-12/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-08-12 @ 2000 EDT / 2025-08-13 @ 0900 JST**
+# Coding Guidelines Subcommittee Meeting on 2025-08-12 @ 2000 EDT / 2025-08-13 @ 0900 JST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,1880252,8,6&h=5&date=2025-8-12&sln=20-21&hf=1) to meeting time in common time zones.
 
@@ -66,4 +66,3 @@ Any material to read before the meeting should be included here.
 ### **GitHub Project Board for Work Items**
 
 * [Work Item Board](https://github.com/orgs/rustfoundation/projects/1)
-

--- a/subcommittee/coding-guidelines/meetings/2025-08-20/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-08-20/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-08-20 @ 0800 BST / 0900 CEST / 1600 JST /  0300 EDT**
+# Coding Guidelines Subcommittee Meeting on 2025-08-20 @ 0800 BST / 0900 CEST / 1600 JST /  0300 EDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=14,12,1850147,5&h=14&date=2025-8-20&sln=8-9&hf=1) to meeting time in common time zones.
 
@@ -88,4 +88,3 @@ Any material to read before the meeting should be included here.
 ### **GitHub Project Board for Work Items**
 
 * [Work Item Board](https://github.com/orgs/rustfoundation/projects/1)
-

--- a/subcommittee/coding-guidelines/meetings/2025-08-27/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-08-27/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-08-27 @ 1100 EDT / 1700 CEST**
+# Coding Guidelines Subcommittee Meeting on 2025-08-27 @ 1100 EDT / 1700 CEST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=14,12,1850147,5&h=14&date=2025-8-20&sln=8-9&hf=1https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,1880252,8,6&h=5&date=2025-8-27&sln=11-12&hf=1) to meeting time in common time zones.
 
@@ -98,4 +98,3 @@ Any material to read before the meeting should be included here.
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)  
 * FLS Maintenance: [FLS Team \- North Star](https://hackmd.io/@plevasseur/HJb6qomOge/edit)  
 * [Github Issue to discuss about panicking in Safety Critical](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/158)
-

--- a/subcommittee/coding-guidelines/meetings/2025-09-02/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-09-02/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-09-02 @ 2000 EDT / 2025-09-03 0900 JST**
+# Coding Guidelines Subcommittee Meeting on 2025-09-02 @ 2000 EDT / 2025-09-03 0900 JST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,1880252,8,6&h=5&date=2025-9-2&sln=20-21&hf=1) to meeting time in common time zones.
 
@@ -86,4 +86,3 @@ Any material to read before the meeting should be included here.
 
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)  
 * [Github Issue to discuss about panicking in Safety Critical](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/158)
-

--- a/subcommittee/coding-guidelines/meetings/2025-09-10/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-09-10/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-09-10 @ 0900 CEST**
+# Coding Guidelines Subcommittee Meeting on 2025-09-10 @ 0900 CEST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,1880252,8,6&h=5&date=2025-9-2&sln=20-21&hf=1) to meeting time in common time zones.
 
@@ -67,4 +67,3 @@ Any material to read before the meeting should be included here.
 
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)  
 * [Github Issue to discuss about panicking in Safety Critical](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/158)
-

--- a/subcommittee/coding-guidelines/meetings/2025-09-17/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-09-17/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-09-17 @ 1100 EDT / 1700 CEST**
+# Coding Guidelines Subcommittee Meeting on 2025-09-17 @ 1100 EDT / 1700 CEST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,1880252,8,6,2673730&h=5&date=2025-9-17&sln=11-12&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/coding-guidelines/meetings/2025-09-23/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-09-23/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-09-23 @ 2000 EDT / 2025-09-24 0900 JST**
+# Coding Guidelines Subcommittee Meeting on 2025-09-23 @ 2000 EDT / 2025-09-24 0900 JST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,1880252,8,6,2673730&h=5&date=2025-9-23&sln=20-21&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/coding-guidelines/meetings/2025-10-01/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-10-01/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-10-01 @ 0800 BST / 0900 CEST / 1600 JST / 0300 EDT**
+# Coding Guidelines Subcommittee Meeting on 2025-10-01 @ 0800 BST / 0900 CEST / 1600 JST / 0300 EDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=14,12,1850147,5&h=14&date=2025-10-1&sln=8-9&hf=1) to meeting time in common time zones.
 
@@ -94,4 +94,3 @@ Any material to read before the meeting should be included here.
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)  
 * FLS Maintenance: [FLS Team \- North Star](https://hackmd.io/@plevasseur/HJb6qomOge/edit)  
 * [Github Issue to discuss about panicking in Safety Critical](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/158)
-

--- a/subcommittee/coding-guidelines/meetings/2025-10-08/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-10-08/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-10-08 @ 1100 EDT / 1700 CEST**
+# Coding Guidelines Subcommittee Meeting on 2025-10-08 @ 1100 EDT / 1700 CEST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,8,6,2673730,1261481&h=5&date=2025-10-8&sln=11-12&hf=1) to meeting time in common time zones.
 
@@ -117,4 +117,3 @@ Any material to read before the meeting should be included here.
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)  
 * FLS Maintenance: [FLS Team \- North Star](https://hackmd.io/@plevasseur/HJb6qomOge/edit)  
 * [Github Issue to discuss about panicking in Safety Critical](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/158)
-

--- a/subcommittee/coding-guidelines/meetings/2025-10-22/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-10-22/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-10-22 @ 0800 BST / 0900 CEST / 1600 JST / 0300 EDT**
+# Coding Guidelines Subcommittee Meeting on 2025-10-22 @ 0800 BST / 0900 CEST / 1600 JST / 0300 EDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=14,12,1850147,5&h=14&date=2025-10-22&sln=8-9&hf=1) to meeting time in common time zones.
 
@@ -123,4 +123,3 @@ Any material to read before the meeting should be included here.
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)  
 * FLS Maintenance: [FLS Team \- North Star](https://hackmd.io/@plevasseur/HJb6qomOge/edit)  
 * [Github Issue to discuss about panicking in Safety Critical](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/158)
-

--- a/subcommittee/coding-guidelines/meetings/2025-10-29/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-10-29/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-10-29 @ 1100 EDT / 1600 CET**
+# Coding Guidelines Subcommittee Meeting on 2025-10-29 @ 1100 EDT / 1600 CET
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,8,6,2673730,1261481&h=5&date=2025-10-29&sln=11-12&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/coding-guidelines/meetings/2025-11-04/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-11-04/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-11-04 @ 2000 EST / 2025-11-05 1000 JST**
+# Coding Guidelines Subcommittee Meeting on 2025-11-04 @ 2000 EST / 2025-11-05 1000 JST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,8,6,2673730,1261481&h=5&date=2025-11-4&sln=20-21&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/coding-guidelines/meetings/2025-11-12/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-11-12/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-11-12 @ 0800 UTC / 0900 CET / 1700 JST**
+# Coding Guidelines Subcommittee Meeting on 2025-11-12 @ 0800 UTC / 0900 CET / 1700 JST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=14,12,1850147,5&h=14&date=2025-11-12&sln=8-9&hf=1) to meeting time in common time zones.
 
@@ -120,4 +120,3 @@ Any material to read before the meeting should be included here.
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)  
 * FLS Maintenance: [FLS Team \- North Star](https://hackmd.io/@plevasseur/HJb6qomOge/edit)  
 * [Github Issue to discuss about panicking in Safety Critical](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/158)
-

--- a/subcommittee/coding-guidelines/meetings/2025-11-19/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-11-19/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-11-19 @ 1100 EDT / 1700 CET**
+# Coding Guidelines Subcommittee Meeting on 2025-11-19 @ 1100 EDT / 1700 CET
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,8,6,2673730,1261481&h=5&date=2025-11-19&sln=11-12&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/coding-guidelines/meetings/2025-11-26/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-11-26/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-11-25 @ 20:00 EST / 2025-11-26 10:00 CET**
+# Coding Guidelines Subcommittee Meeting on 2025-11-25 @ 20:00 EST / 2025-11-26 10:00 CET
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,8,6,2673730,1261481&h=5&date=2025-11-25&sln=20-21&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/coding-guidelines/meetings/2025-12-03/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-12-03/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-12-03 @ 0800 UTC / 0900 CET / 1700 JST / 0300 EST**
+# Coding Guidelines Subcommittee Meeting on 2025-12-03 @ 0800 UTC / 0900 CET / 1700 JST / 0300 EST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=14,12,1850147,5&h=14&date=2025-12-3&sln=8-9&hf=1) to meeting time in common time zones.
 
@@ -104,4 +104,3 @@ Any material to read before the meeting should be included here.
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)  
 * FLS Maintenance: [FLS Team \- North Star](https://hackmd.io/@plevasseur/HJb6qomOge/edit)  
 * [Github Issue to discuss about panicking in Safety Critical](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/158)
-

--- a/subcommittee/coding-guidelines/meetings/2025-12-10/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-12-10/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-12-10 @ 1700 CEST / 1100 EDT**
+# Coding Guidelines Subcommittee Meeting on 2025-12-10 @ 1700 CEST / 1100 EDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,100,2643743,12,1850147,2193733,8,6,2673730,1261481&h=5&date=2025-12-10&sln=11-12&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/coding-guidelines/meetings/2025-12-17/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2025-12-17/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-12-16 @ 20:00 EST / 2025-12-17 10:00 JST**
+# Coding Guidelines Subcommittee Meeting on 2025-12-16 @ 20:00 EST / 2025-12-17 10:00 JST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,1850147,212&h=5&date=2025-12-16&sln=20-21&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/coding-guidelines/meetings/2026-01-14/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2026-01-14/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2025-12-03 @ 0800 UTC / 0900 CET / 1700 JST / 0300 EST**
+# Coding Guidelines Subcommittee Meeting on 2025-12-03 @ 0800 UTC / 0900 CET / 1700 JST / 0300 EST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=14,12,1850147,5&h=14&date=2026-01-14&sln=8-9&hf=1) to meeting time in common time zones.
 
@@ -89,4 +89,3 @@ Any material to read before the meeting should be included here.
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)  
 * FLS Maintenance: [FLS Team \- North Star](https://hackmd.io/@plevasseur/HJb6qomOge/edit)  
 * [Github Issue to discuss about panicking in Safety Critical](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/158)
-

--- a/subcommittee/coding-guidelines/meetings/2026-01-21/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2026-01-21/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2026-01-21 @ 1700 CEST / 1100 EDT**
+# Coding Guidelines Subcommittee Meeting on 2026-01-21 @ 1700 CEST / 1100 EDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=2643743,12,8,5&h=5&date=2026-1-21&sln=11-12&hf=1) to meeting time in common time zones.
 
@@ -100,4 +100,3 @@ For tips on how we take notes in the Safety-Critical Rust Consortium, please see
 Any material to read before the meeting should be included here.
 
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)
-

--- a/subcommittee/coding-guidelines/meetings/2026-01-27/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2026-01-27/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2026-01-27 @ 20:00 EST / 2026-01-28 @ 10:00 JST**
+# Coding Guidelines Subcommittee Meeting on 2026-01-27 @ 20:00 EST / 2026-01-28 @ 10:00 JST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=2643743,12,8,5,1850147&h=5&date=2026-1-27&sln=20-21&hf=1) to meeting time in common time zones.
 
@@ -86,4 +86,3 @@ For tips on how we take notes in the Safety-Critical Rust Consortium, please see
 Any material to read before the meeting should be included here.
 
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)
-

--- a/subcommittee/coding-guidelines/meetings/2026-02-11/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2026-02-11/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2026-02-11 @ 1700 CET / 1100 EDT**
+# Coding Guidelines Subcommittee Meeting on 2026-02-11 @ 1700 CET / 1100 EDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=2643743,12,8,5&h=5&date=2026-2-11&sln=11-12&hf=1) to meeting time in common time zones.
 
@@ -99,4 +99,3 @@ For tips on how we take notes in the Safety-Critical Rust Consortium, please see
 Any material to read before the meeting should be included here.
 
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)
-

--- a/subcommittee/coding-guidelines/meetings/2026-02-25/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2026-02-25/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2026-02-25 @ 17:00 JST / 09:00 CET**
+# Coding Guidelines Subcommittee Meeting on 2026-02-25 @ 17:00 JST / 09:00 CET
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=2643743,12,5,1850147,100&h=2643743&date=2026-2-25&sln=8-9&hf=1) to meeting time in common time zones.
 
@@ -91,4 +91,3 @@ For tips on how we take notes in the Safety-Critical Rust Consortium, please see
 Any material to read before the meeting should be included here.
 
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)
-

--- a/subcommittee/coding-guidelines/meetings/2026-03-04/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2026-03-04/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2026-03-04 @ 1700 CET / 1100 EST**
+# Coding Guidelines Subcommittee Meeting on 2026-03-04 @ 1700 CET / 1100 EST
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,2643743,12,8,1850147,100,14&h=5&date=2026-3-4&sln=11-12&hf=1) to meeting time in common time zones.
 
@@ -105,4 +105,3 @@ For tips on how we take notes in the Safety-Critical Rust Consortium, please see
 Any material to read before the meeting should be included here.
 
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)
-

--- a/subcommittee/coding-guidelines/meetings/2026-03-11/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2026-03-11/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2026-03-11 @ 1600 CET / 1100 EDT**
+# Coding Guidelines Subcommittee Meeting on 2026-03-11 @ 1600 CET / 1100 EDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,12,2643743,8,1850147,100,14&h=5&date=2026-3-11&sln=11-12&hf=1) to meeting time in common time zones.
 
@@ -80,4 +80,3 @@ For tips on how we take notes in the Safety-Critical Rust Consortium, please see
 Any material to read before the meeting should be included here.
 
 * Milestone: [Prepare for launch to wider Rust community](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/milestone/1)
-

--- a/subcommittee/coding-guidelines/meetings/2026-03-18/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2026-03-18/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2026-03-18 @ 1600 CET / 1100 EDT**
+# Coding Guidelines Subcommittee Meeting on 2026-03-18 @ 1600 CET / 1100 EDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,12,2643743,8,1850147,100,14&h=5&date=2026-3-18&sln=11-12&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/coding-guidelines/meetings/2026-03-25/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2026-03-25/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2026-03-25 @ 1600 CET / 1100 EDT**
+# Coding Guidelines Subcommittee Meeting on 2026-03-25 @ 1600 CET / 1100 EDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,12,2643743,8,1850147,100,14&h=5&date=2026-3-25&sln=11-12&hf=1) to meeting time in common time zones.
 
@@ -134,4 +134,4 @@ For tips on how we take notes in the Safety-Critical Rust Consortium, please see
 
 ## **Material**
 
-Any material to read before the meeting should be included here.  
+Any material to read before the meeting should be included here.

--- a/subcommittee/coding-guidelines/meetings/2026-03-27/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2026-03-27/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2026-03-27 @ 0800 JST / 1600 PDT**
+# Coding Guidelines Subcommittee Meeting on 2026-03-27 @ 0800 JST / 1600 PDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,12,2643743,8,1850147,100,14&h=5&date=2026-3-25&sln=11-12&hf=1) to meeting time in common time zones.
 
@@ -73,4 +73,4 @@ For tips on how we take notes in the Safety-Critical Rust Consortium, please see
 
 ## **Material**
 
-Any material to read before the meeting should be included here.  
+Any material to read before the meeting should be included here.

--- a/subcommittee/coding-guidelines/meetings/2026-04-01/minutes.md
+++ b/subcommittee/coding-guidelines/meetings/2026-04-01/minutes.md
@@ -1,4 +1,4 @@
-# **Coding Guidelines Subcommittee Meeting on 2026-04-01 @ 1600 CEST / 1100 EDT**
+# Coding Guidelines Subcommittee Meeting on 2026-04-01 @ 1600 CEST / 1100 EDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=5,12,2643743,8,1850147,100,14&h=5&date=2026-4-1&sln=11-12&hf=1) to meeting time in common time zones.
 
@@ -143,4 +143,4 @@ For tips on how we take notes in the Safety-Critical Rust Consortium, please see
 
 ## **Material**
 
-Any material to read before the meeting should be included here.  
+Any material to read before the meeting should be included here.

--- a/subcommittee/coding-guidelines/meetings/_category_.json
+++ b/subcommittee/coding-guidelines/meetings/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 4,
+  "label": "Meetings",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/subcommittee/liaison/meetings/2025-04-25/minutes.md
+++ b/subcommittee/liaison/meetings/2025-04-25/minutes.md
@@ -1,4 +1,4 @@
-# **Liaison Subcommittee Meeting on 2025-04-25 @ 2 PM UTC**
+# Liaison Subcommittee Meeting on 2025-04-25 @ 2 PM UTC
 
 [Conversion](https://www.worldtimebuddy.com/?qm=1&lid=5,14,8,12&h=5&date=2025-4-25&sln=10-11&hf=1) between common time zones of attendees.
 
@@ -93,5 +93,4 @@
 
 Any material to read before the meeting should be included here.
 
-* 
-
+*

--- a/subcommittee/liaison/meetings/2025-10-02/minutes.md
+++ b/subcommittee/liaison/meetings/2025-10-02/minutes.md
@@ -1,4 +1,4 @@
-# **Liaison Subcommittee Meeting on 2025-10-02 @ 1600 BST / 1700 CEST / 1100 EDT**
+# Liaison Subcommittee Meeting on 2025-10-02 @ 1600 BST / 1700 CEST / 1100 EDT
 
 [Link](https://www.worldtimebuddy.com/?qm=1&lid=14,12,1850147,5&h=14&date=2025-10-2&sln=16-17&hf=1) to meeting time in common time zones.
 

--- a/subcommittee/liaison/meetings/_category_.json
+++ b/subcommittee/liaison/meetings/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 2,
+  "label": "Meetings",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/subcommittee/tooling/meetings/_category_.json
+++ b/subcommittee/tooling/meetings/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 6,
+  "label": "Meetings",
+  "collapsible": true,
+  "collapsed": true
+}


### PR DESCRIPTION
This pul request publishes the meeting notes for the coding guidelines, tooling and liaison subcommittees to arewesafetycriticalyet.org.

## Advantages

Meeting notes will be automatically published to arewesafetycriticalyet.org and will also be visible in their folder on the repository.

## Disadvantages

To avoid content duplication, the `meetings` folder for each subcommittee is sym linked into the docs folder. This has two drawbacks:
- The build will fail on Windows (but will work on WSL).
- Following symlinks might pose a security risk when building.
- Links to `mission_statement.md` and `initiatives` have to be absolute (pointing to `https://github.com/rustfoundation/safety-critical-rust-consortium/tree/main/subcommittee/coding-guidelines/`)[^allinfo], solvable.

## Still needed
- requires #624 to fix the typo for the name

[^allinfo]: This can be mitigated if we post all the info on the website, but this requires some work.