### PR TITLE
Mention DO-330 in tracked standards

### DIFF
--- a/arewesafetycriticalyet.org/src/components/ToolsList/available-tools.json
+++ b/arewesafetycriticalyet.org/src/components/ToolsList/available-tools.json
@@ -12,7 +12,7 @@
       {
         "name": "DO-178C",
         "levels": ["DAL E", "DAL D", "DAL C", "DAL B", "DAL A"],
-        "description": "Software Considerations in Airborne Systems and Equipment Certification"
+        "description": "Software Considerations in Airborne Systems and Equipment Certification. Note that tool qualification is covered by DO-330, which we don't track separately here."
       },
       {
         "name": "IEC 62304",


### PR DESCRIPTION
DO-178C has several sub-standards that work together with the main standard.
For tool qualification, there is DO-330.

To keep the tools list and related standards simple, this PR adds a note mentioning DO-330, but keeps DO-178C as the aerospace standard that gets mapped to tools.