### PR TITLE
Add new railway standard

### DIFF
--- a/arewesafetycriticalyet.org/src/components/ToolsList/available-tools.json
+++ b/arewesafetycriticalyet.org/src/components/ToolsList/available-tools.json
@@ -28,6 +28,11 @@
         "name": "EN 50128",
         "levels": ["SIL 1", "SIL 2", "SIL 3", "SIL 4"],
         "description": "Railway applications - Communication, signalling and processing systems - Software for railway control and protection systems"
+      },
+      {
+        "name": "EN 50716",
+        "levels": ["SIL 1", "SIL 2", "SIL 3", "SIL 4"],
+        "description": "Railway Applications - Requirements for software development. This supersedes EN 50128."
       }
     ]
   },


### PR DESCRIPTION
This PR adds the railway standard EN 50716 to the tracked standards of the tools list.
The standard supersedes EN 50128 as of 2024.

Since some tools may only be qualified for EN 50128, I decided to keep both standards in the list.